### PR TITLE
Add image dataset importer

### DIFF
--- a/libs/core/kiln_ai/utils/__init__.py
+++ b/libs/core/kiln_ai/utils/__init__.py
@@ -4,9 +4,10 @@
 Misc utilities used in the kiln_ai library.
 """
 
-from . import config, formatting
+from . import config, formatting, image_utils
 
 __all__ = [
     "config",
     "formatting",
+    "image_utils",
 ]

--- a/libs/core/kiln_ai/utils/dataset_import.py
+++ b/libs/core/kiln_ai/utils/dataset_import.py
@@ -1,5 +1,6 @@
 import csv
 import logging
+import os
 import random
 import time
 from dataclasses import dataclass
@@ -9,16 +10,16 @@ from typing import Dict, Protocol
 from pydantic import BaseModel, Field, ValidationError
 
 from kiln_ai.datamodel import DataSource, DataSourceType, Task, TaskOutput, TaskRun
+from kiln_ai.utils import image_utils
 
 logger = logging.getLogger(__name__)
 
 
 class DatasetImportFormat(str, Enum):
-    """
-    The format of the dataset to import.
-    """
+    """The format of the dataset to import."""
 
     CSV = "csv"
+    IMAGES = "images"
 
 
 @dataclass
@@ -273,8 +274,61 @@ def import_csv(
     return len(rows)
 
 
+def import_images(
+    task: Task,
+    config: ImportConfig,
+) -> int:
+    """Import a directory of images as base64 encoded inputs."""
+
+    session_id = str(int(time.time()))
+    dataset_path = config.dataset_path
+    dataset_name = config.dataset_name
+    tag_splits = config.tag_splits
+
+    rows: list[TaskRun] = []
+
+    if not os.path.isdir(dataset_path):
+        raise KilnInvalidImportFormat("Dataset path must be a directory of images")
+
+    for file_name in os.listdir(dataset_path):
+        file_path = os.path.join(dataset_path, file_name)
+        if not os.path.isfile(file_path):
+            continue
+        try:
+            encoded = image_utils.image_file_to_base64(file_path)
+        except Exception as e:  # pragma: no cover - log error and skip
+            logger.warning(f"Failed to encode {file_name}: {e}")
+            continue
+
+        run = TaskRun(
+            parent=task,
+            input=encoded,
+            input_source=DataSource(
+                type=DataSourceType.file_import,
+                properties={"file_name": file_name},
+            ),
+            output=TaskOutput(
+                output="",
+                source=DataSource(
+                    type=DataSourceType.file_import,
+                    properties={"file_name": dataset_name},
+                ),
+            ),
+            tags=generate_import_tags(session_id),
+        )
+        rows.append(run)
+
+    add_tag_splits(rows, tag_splits)
+
+    for run in rows:
+        run.save_to_file()
+
+    return len(rows)
+
+
 DATASET_IMPORTERS: Dict[DatasetImportFormat, Importer] = {
     DatasetImportFormat.CSV: import_csv,
+    DatasetImportFormat.IMAGES: import_images,
 }
 
 

--- a/libs/core/kiln_ai/utils/image_utils.py
+++ b/libs/core/kiln_ai/utils/image_utils.py
@@ -1,0 +1,9 @@
+import base64
+from pathlib import Path
+
+
+def image_file_to_base64(path: str | Path) -> str:
+    """Read an image from a file and return a base64 encoded string."""
+    with open(Path(path), "rb") as img_file:
+        data = img_file.read()
+    return base64.b64encode(data).decode("utf-8")

--- a/libs/core/kiln_ai/utils/test_dataset_import.py
+++ b/libs/core/kiln_ai/utils/test_dataset_import.py
@@ -1,3 +1,4 @@
+import base64
 import csv
 import json
 import logging
@@ -25,6 +26,7 @@ from kiln_ai.utils.dataset_import import (
     deserialize_tags,
     format_validation_error,
     generate_import_tags,
+    image_utils,
     without_none_values,
 )
 
@@ -856,3 +858,39 @@ def test_dataset_file_importer_validates_tag_splits(base_task: Task, tmp_path):
         ),
     )
     assert importer.config.tag_splits == {"train": 0.7, "test": 0.3}
+
+
+def test_image_file_to_base64(tmp_path):
+    image_path = tmp_path / "img.bin"
+    image_bytes = b"binarydata"
+    image_path.write_bytes(image_bytes)
+
+    encoded = image_utils.image_file_to_base64(image_path)
+    assert encoded == base64.b64encode(image_bytes).decode("utf-8")
+
+
+def test_import_images(base_task: Task, tmp_path):
+    img_dir = tmp_path / "imgs"
+    img_dir.mkdir()
+
+    img1 = img_dir / "one.bin"
+    img1.write_bytes(b"one")
+    img2 = img_dir / "two.bin"
+    img2.write_bytes(b"two")
+
+    importer = DatasetFileImporter(
+        base_task,
+        ImportConfig(
+            dataset_type=DatasetImportFormat.IMAGES,
+            dataset_path=str(img_dir),
+            dataset_name="imgs",
+        ),
+    )
+
+    count = importer.create_runs_from_file()
+    assert count == 2
+    assert len(base_task.runs()) == 2
+
+    contents = {run.input for run in base_task.runs()}
+    assert base64.b64encode(b"one").decode("utf-8") in contents
+    assert base64.b64encode(b"two").decode("utf-8") in contents


### PR DESCRIPTION
## Summary
- add `image_file_to_base64` helper
- support `IMAGES` dataset format
- import images from folder as base64 data
- expose new utils
- test importing images

## Testing
- `uvx ruff check --select I`
- `uvx ruff format --check .`
- `uv run pyright .`
- `uv run python3 -m pytest --benchmark-quiet -q .`


------
https://chatgpt.com/codex/tasks/task_e_6876ad36c668833099f6547f10158071